### PR TITLE
Adapt tests to the updated navigator.cookieEnabled behavior.

### DIFF
--- a/static/js/frames/ephemeral-storage.js
+++ b/static/js/frames/ephemeral-storage.js
@@ -31,7 +31,7 @@
   const clearStorage = async key => {
     const result = Object.create(null)
     try {
-      if (W.navigator.cookieEnabled === false) {
+      if (W.navigator.cookieEnabled === false || !await W.document.hasStorageAccess()) {
         result['dom-cookies'] = exceptionEncoding
       } else {
         C.remove(key, {
@@ -71,7 +71,7 @@
   const readStorageAction = async key => {
     const result = Object.create(null)
     try {
-      if (W.navigator.cookieEnabled === false) {
+      if (W.navigator.cookieEnabled === false || !await W.document.hasStorageAccess()) {
         result['dom-cookies'] = exceptionEncoding
       } else {
         const readCookieValue = C.get(key)
@@ -106,7 +106,7 @@
   const writeStorageAction = async (key, value) => {
     const result = Object.create(null)
     try {
-      if (W.navigator.cookieEnabled === false) {
+      if (W.navigator.cookieEnabled === false || !await W.document.hasStorageAccess()) {
         result['dom-cookies'] = false
       } else {
         C.set(key, value, {


### PR DESCRIPTION
https://github.com/brave/brave-core/commit/c9586ae44a72e53382d7ef06123220ed572d442d

Chromium change:
commit 2c885728f29b653f404e6a42da86b19e055def72
Author: Ari Chivukula <arichiv@chromium.org>
Date:   Mon May 6 20:03:59 2024 +0000

    [CookieEnabled] Align with spec

    navigator.cookieEnabled currently indicates if “the user agent attempts
    to handle cookies” in a given context. A change in Chrome, shipping as
    part of third-party cookie deprecation (3PCD), would cause it to
    indicate whether unpartitioned cookie access is possible (causing it to
    return false in most cross-site iframes). We should restore the prior
    behavior of navigator.cookieEnabled which indicated only if cookies were
    enabled/disabled for the site and rely on the cross-vendor function
    document.hasStorageAccess to indicate if unpartitioned cookie access is
    possible.

    https://github.com/whatwg/html/issues/10256
    https://chromestatus.com/feature/6227655153418240
    https://groups.google.com/a/chromium.org/g/blink-dev/c/xU3gTW4aTfg

    Bug: 335553590
    Change-Id: I6cc1f2a9caea6220b6f85240ae9875a65a91d179
    Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5464207
    Commit-Queue: Daniel Cheng <dcheng@chromium.org>
    Auto-Submit: Ari Chivukula <arichiv@chromium.org>
    Reviewed-by: Jonathan Njeunje <njeunje@chromium.org>
    Reviewed-by: Daniel Cheng <dcheng@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#1297071}