### PR TITLE
Validate postMessage origins in frame test handlers

### DIFF
--- a/static/js/site.js
+++ b/static/js/site.js
@@ -127,6 +127,14 @@
     }
   }
 
+  const targetOriginForWindow = windowElm => {
+    try {
+      return windowElm.location.origin
+    } catch (_) {
+      return 'https://' + otherOrigin
+    }
+  }
+
   const sendPostMsg = async (windowElm, action, msg) => {
     return new Promise((resolve) => {
       const messageNonce = Math.random().toString()
@@ -153,7 +161,7 @@
         direction: 'sending',
         action
       }
-      windowElm.postMessage(outMsg, '*')
+      windowElm.postMessage(outMsg, targetOriginForWindow(windowElm))
     })
   }
 

--- a/static/js/site.js
+++ b/static/js/site.js
@@ -180,7 +180,7 @@
         nonce
       }
 
-      msg.source.postMessage(response, '*')
+      msg.source.postMessage(response, msg.origin)
     }
 
     W.addEventListener('message', onMessage, false)

--- a/static/js/site.js
+++ b/static/js/site.js
@@ -16,6 +16,11 @@
   const braveSoftwareOrigin = 'dev-pages.bravesoftware.com'
   const braveSoftwareComOrigin = 'dev-pages.brave.software'
 
+  const allowedMessageOrigins = new Set([
+    'https://' + braveSoftwareOrigin,
+    'https://' + braveSoftwareComOrigin
+  ])
+
   const thisOrigin = W.location.host
   const onlyLocal = W.location.protocol === 'http:'
   let otherOrigin
@@ -126,6 +131,9 @@
     return new Promise((resolve) => {
       const messageNonce = Math.random().toString()
       const onResponseCallback = response => {
+        if (!allowedMessageOrigins.has(response.origin)) {
+          return
+        }
         const { nonce, direction, payload } = response.data
         if (direction !== 'response') {
           return
@@ -151,6 +159,9 @@
 
   const receivePostMsg = async handler => {
     const onMessage = async msg => {
+      if (!allowedMessageOrigins.has(msg.origin)) {
+        return
+      }
       const { action, payload, direction, nonce } = msg.data
       if (direction !== 'sending') {
         return


### PR DESCRIPTION
Frame postMessage handlers accepted messages from any origin and sent with targetOrigin='*'.

Fix:
- Validate `event.origin` against the two test origins before handling messages.
- Send to explicit origins instead of `*`.